### PR TITLE
Mensaje error repetido

### DIFF
--- a/src/app/features/auth/login/login.component.ts
+++ b/src/app/features/auth/login/login.component.ts
@@ -108,13 +108,13 @@ export class LoginComponent {
         // Manejar diferentes tipos de errores
         if (error.status === 401) {
           this.errorMessage.set('Usuario o contraseña incorrectos.');
-          this.info.showError('Usuario o contraseña incorrectos.');
+          //this.info.showError('Usuario o contraseña incorrectos.');
         } else if (error.status === 429) {
           this.errorMessage.set('Demasiados intentos. Por favor, intenta más tarde.');
-          this.info.showError('Demasiados intentos. Por favor, intenta más tarde.');
+          //this.info.showError('Demasiados intentos. Por favor, intenta más tarde.');
         } else {
           this.errorMessage.set('Error al iniciar sesión. Por favor, intenta nuevamente.');
-          this.info.showError('Error al iniciar sesión. Por favor, intenta nuevamente.');
+          //this.info.showError('Error al iniciar sesión. Por favor, intenta nuevamente.');
         }
       }
     });


### PR DESCRIPTION
### Tarea: 
Corregir el error visual de dos mensajes de error en la pantalla del Login 
### Observación:
En la parte de "Manejo de diferentes tipos de errores" en el código del Login, se puede observar cómo el mismo mensaje de error es enviado dos veces a la página pero que son de diferente tipo, uno es de tipo error y el otro es de tipo info.

**Antes:**
<img width="982" height="909" alt="image" src="https://github.com/user-attachments/assets/6e3ea237-cc49-4d93-bc71-cd22e3344c04" />

**Después:**
<img width="686" height="826" alt="Captura de pantalla 2026-04-16 184757" src="https://github.com/user-attachments/assets/8cf05aae-f296-45a4-a0d2-791f27780d33" />

### Modificaciones:
- Para evitar la repetición del mismo mensaje, se puso como comentario todos los errores de tipo info para evitar su envío a la página.
- La ruta del archivo modificado es el siguiente: frontend-private\src\app\features\auth\login\login.component.ts