### PR TITLE
fix: ocultar configuración de evaluación en encuestas de satisfacción #13

### DIFF
--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -9,11 +9,6 @@ const SUBMISSION_ID = 'ffffffffffffffffffffffff';
 
 export { COURSE_ID, QUESTIONNAIRE_ID, CLASS_ID, STUDENT_USER_ID, PROFESOR_USER_ID, SUBMISSION_ID };
 
-/**
- * Genera un token JWT fake con exp muy lejano (año 2286).
- * El frontend sólo decodifica el payload para verificar expiración —
- * no valida la firma— así que esto funciona para tests E2E.
- */
 function makeFakeJwt(payload: object): string {
   const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
     .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
@@ -22,7 +17,6 @@ function makeFakeJwt(payload: object): string {
   return `${header}.${body}.fakesignature`;
 }
 
-/** Inyecta sesión de ALUMNO en localStorage via addInitScript (corre antes de Angular). */
 export async function injectAlumnoAuth(page: Page): Promise<void> {
   const user = {
     _id: STUDENT_USER_ID,
@@ -43,7 +37,6 @@ export async function injectAlumnoAuth(page: Page): Promise<void> {
   );
 }
 
-/** Inyecta sesión de PROFESOR en localStorage via addInitScript (corre antes de Angular). */
 export async function injectProfesorAuth(page: Page): Promise<void> {
   const user = {
     _id: PROFESOR_USER_ID,

--- a/e2e/questionnaire-survey.spec.ts
+++ b/e2e/questionnaire-survey.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * E2E Tests — Fix: Encuestas de satisfacción no deben mostrar
+ * configuración de nota mínima, reintentos ni respuestas correctas.
+ */
+
+import { test, expect, Page, Route } from '@playwright/test';
+import {
+  injectProfesorAuth,
+  COURSE_ID,
+  QUESTIONNAIRE_ID,
+} from './helpers/auth';
+
+const API = 'http://localhost:8081/api/v1';
+
+async function mockQuestionnairesListWithSurvey(page: Page) {
+  await page.route(`${API}/questionnaires/course/${COURSE_ID}`, (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: [
+          {
+            _id: QUESTIONNAIRE_ID,
+            courseId: COURSE_ID,
+            title: 'Encuesta de Satisfacción',
+            status: 'ACTIVE',
+            isSurvey: true,
+            passingScore: 70,
+            allowRetries: false,
+            showCorrectAnswers: false,
+            position: { type: 'FINAL_EXAM' },
+            questions: [],
+          },
+        ],
+      }),
+    })
+  );
+}
+
+async function mockQuestionnairesListWithRegular(page: Page) {
+  await page.route(`${API}/questionnaires/course/${COURSE_ID}`, (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: [
+          {
+            _id: QUESTIONNAIRE_ID,
+            courseId: COURSE_ID,
+            title: 'Examen Final',
+            status: 'ACTIVE',
+            isSurvey: false,
+            passingScore: 70,
+            allowRetries: false,
+            showCorrectAnswers: false,
+            position: { type: 'FINAL_EXAM' },
+            questions: [],
+          },
+        ],
+      }),
+    })
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('Fix — Encuestas no muestran configuración de evaluación', () => {
+
+  test('Card de encuesta muestra badge y NO muestra nota mínima, reintentos ni respuestas correctas', async ({ page }) => {
+    await injectProfesorAuth(page);
+    await mockQuestionnairesListWithSurvey(page);
+
+    await page.goto(`/profesor/questionnaires?courseId=${COURSE_ID}`);
+    await page.waitForSelector('text=Encuesta de Satisfacción', { timeout: 10000 });
+
+    await expect(page.locator('text=📋 Encuesta de Satisfacción').first()).toBeVisible();
+    await expect(page.locator('text=Puntuación automática: 100%')).toBeVisible();
+    await expect(page.locator('text=No evalúa respuestas correctas')).toBeVisible();
+    await expect(page.locator('text=Nota mínima')).not.toBeVisible();
+    await expect(page.locator('text=Sin reintentos')).not.toBeVisible();
+    await expect(page.locator('text=Oculta respuestas correctas')).not.toBeVisible();
+  });
+
+  test('Card de cuestionario normal NO muestra badge de encuesta y SÍ muestra configuración', async ({ page }) => {
+    await injectProfesorAuth(page);
+    await mockQuestionnairesListWithRegular(page);
+
+    await page.goto(`/profesor/questionnaires?courseId=${COURSE_ID}`);
+    await page.waitForSelector('text=Examen Final', { timeout: 10000 });
+
+    await expect(page.locator('text=📋 Encuesta de Satisfacción')).not.toBeVisible();
+    await expect(page.locator('text=Nota mínima: 70%')).toBeVisible();
+    await expect(page.locator('text=Sin reintentos')).toBeVisible();
+    await expect(page.locator('text=Oculta respuestas correctas')).toBeVisible();
+  });
+
+  test('Formulario de edición oculta sección Configuración al marcar isSurvey', async ({ page }) => {
+    await injectProfesorAuth(page);
+
+    await page.goto(`/profesor/questionnaires/new?courseId=${COURSE_ID}`);
+    await page.waitForSelector('text=Información Básica', { timeout: 10000 });
+
+    await expect(page.locator('text=Configuración')).toBeVisible();
+    await page.locator('#isSurvey').check();
+    await expect(page.locator('text=Configuración')).not.toBeVisible();
+  });
+
+  test('Formulario de edición muestra sección Configuración al desmarcar isSurvey', async ({ page }) => {
+    await injectProfesorAuth(page);
+
+    await page.goto(`/profesor/questionnaires/new?courseId=${COURSE_ID}`);
+    await page.waitForSelector('text=Información Básica', { timeout: 10000 });
+
+    await page.locator('#isSurvey').check();
+    await expect(page.locator('text=Configuración')).not.toBeVisible();
+    await page.locator('#isSurvey').uncheck();
+    await expect(page.locator('text=Configuración')).toBeVisible();
+  });
+});

--- a/src/app/features/profesor/questionnaires/question-item/question-item.component.spec.ts
+++ b/src/app/features/profesor/questionnaires/question-item/question-item.component.spec.ts
@@ -1,0 +1,297 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule, FormGroup, FormArray, FormControl, Validators, AbstractControl } from '@angular/forms';
+import { QuestionItemComponent } from './question-item.component';
+import { InfoService } from '../../../../core/services/info.service';
+import { QuestionMediaUploadManagerService } from '../../../../core/services/question-media-upload-manager.service';
+import { QuestionnairesService } from '../../../../core/services/questionnaires.service';
+import { Subject } from 'rxjs';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function createOptionGroup(text = ''): FormGroup {
+  return new FormGroup({
+    _id: new FormControl(null),
+    text: new FormControl(text, [Validators.required, Validators.maxLength(500)]),
+    order: new FormControl(0)
+  });
+}
+
+function createQuestionGroup(type: string = 'MULTIPLE_CHOICE'): FormGroup {
+  const optionsArray = new FormArray<FormGroup>([]);
+  for (let i = 0; i < 4; i++) {
+    optionsArray.push(createOptionGroup(`Opción ${i + 1}`));
+  }
+
+  return new FormGroup({
+    type: new FormControl(type),
+    questionText: new FormControl('Pregunta de prueba'),
+    points: new FormControl(10),
+    required: new FormControl(true),
+    options: optionsArray,
+    correctOptionId: new FormControl(''),
+    correctOptionIds: new FormControl<string[]>([]),
+    originalCorrectOptionId: new FormControl(null),
+    originalCorrectOptionIds: new FormControl<string[]>([]),
+    promptType: new FormControl('TEXT'),
+    promptMediaUrl: new FormControl(''),
+    promptMediaProvider: new FormControl('BUNNY')
+  });
+}
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const infoServiceMock = {
+  showError: jasmine.createSpy('showError'),
+  showInfo: jasmine.createSpy('showInfo'),
+  showSuccess: jasmine.createSpy('showSuccess')
+};
+
+const uploadManagerMock = {
+  startUpload: jasmine.createSpy('startUpload').and.returnValue({ started: false }),
+  uploadCompleted$: new Subject()
+};
+
+const questionnairesServiceMock = {
+  getQuestionnaireById: jasmine.createSpy('getQuestionnaireById')
+};
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('QuestionItemComponent', () => {
+  let component: QuestionItemComponent;
+  let fixture: ComponentFixture<QuestionItemComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [QuestionItemComponent, ReactiveFormsModule],
+      providers: [
+        { provide: InfoService, useValue: infoServiceMock },
+        { provide: QuestionMediaUploadManagerService, useValue: uploadManagerMock },
+        { provide: QuestionnairesService, useValue: questionnairesServiceMock }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(QuestionItemComponent);
+    component = fixture.componentInstance;
+  });
+
+  // ── onQuestionTypeChange ────────────────────────────────────────────────
+
+  describe('onQuestionTypeChange()', () => {
+
+    it('debe preservar el texto de las opciones al cambiar de MULTIPLE_CHOICE a MULTIPLE_SELECT', () => {
+      // Arrange: pregunta MULTIPLE_CHOICE con 4 opciones con texto
+      const questionGroup = createQuestionGroup('MULTIPLE_CHOICE');
+      component.question = questionGroup as AbstractControl;
+      fixture.detectChanges();
+
+      const textoEsperado = ['Alpha', 'Beta', 'Gamma', 'Delta'];
+      const options = questionGroup.get('options') as FormArray;
+      textoEsperado.forEach((txt, i) => options.at(i).get('text')?.setValue(txt));
+
+      // Act: cambiar tipo a MULTIPLE_SELECT
+      questionGroup.get('type')?.setValue('MULTIPLE_SELECT');
+      component.onQuestionTypeChange();
+
+      // Assert: los textos se preservaron
+      const optionsAfter = (component.question as FormGroup).get('options') as FormArray;
+      textoEsperado.forEach((txt, i) => {
+        expect(optionsAfter.at(i).get('text')?.value).toBe(txt,
+          `La opción ${i + 1} debería conservar el texto "${txt}"`);
+      });
+    });
+
+    it('debe preservar el texto de las opciones al cambiar de MULTIPLE_SELECT a MULTIPLE_CHOICE', () => {
+      // Arrange
+      const questionGroup = createQuestionGroup('MULTIPLE_SELECT');
+      component.question = questionGroup as AbstractControl;
+      fixture.detectChanges();
+
+      const textos = ['Opción A', 'Opción B', 'Opción C', 'Opción D'];
+      const options = questionGroup.get('options') as FormArray;
+      textos.forEach((txt, i) => options.at(i).get('text')?.setValue(txt));
+
+      // Act
+      questionGroup.get('type')?.setValue('MULTIPLE_CHOICE');
+      component.onQuestionTypeChange();
+
+      // Assert
+      const optionsAfter = (component.question as FormGroup).get('options') as FormArray;
+      textos.forEach((txt, i) => {
+        expect(optionsAfter.at(i).get('text')?.value).toBe(txt);
+      });
+    });
+
+    it('debe resetear correctOptionId y correctOptionIds al cambiar de tipo', () => {
+      // Arrange
+      const questionGroup = createQuestionGroup('MULTIPLE_CHOICE');
+      questionGroup.patchValue({ correctOptionId: '2', correctOptionIds: ['0', '1'] });
+      component.question = questionGroup as AbstractControl;
+      fixture.detectChanges();
+
+      // Act
+      questionGroup.get('type')?.setValue('MULTIPLE_SELECT');
+      component.onQuestionTypeChange();
+
+      // Assert
+      expect(questionGroup.get('correctOptionId')?.value).toBe('');
+      expect(questionGroup.get('correctOptionIds')?.value).toEqual([]);
+    });
+
+    it('debe limpiar las opciones al cambiar a tipo TEXT', () => {
+      // Arrange
+      const questionGroup = createQuestionGroup('MULTIPLE_CHOICE');
+      component.question = questionGroup as AbstractControl;
+      fixture.detectChanges();
+
+      // Act
+      questionGroup.get('type')?.setValue('TEXT');
+      component.onQuestionTypeChange();
+
+      // Assert
+      const optionsAfter = (component.question as FormGroup).get('options') as FormArray;
+      expect(optionsAfter.length).toBe(0);
+    });
+
+    it('NO debe mostrar error de opciones vacías después de cambiar tipo si las opciones tienen texto', () => {
+      // Arrange — este es el caso exacto del bug report
+      const questionGroup = createQuestionGroup('MULTIPLE_CHOICE');
+      component.question = questionGroup as AbstractControl;
+      fixture.detectChanges();
+
+      // Completar todas las opciones
+      const options = questionGroup.get('options') as FormArray;
+      ['Texto 1', 'Texto 2', 'Texto 3', 'Texto 4'].forEach((txt, i) =>
+        options.at(i).get('text')?.setValue(txt)
+      );
+
+      // Act: cambiar tipo (reproduce el bug)
+      questionGroup.get('type')?.setValue('MULTIPLE_SELECT');
+      component.onQuestionTypeChange();
+
+      // Assert: no debe haber error de optionTextEmpty
+      const errors = questionGroup.errors;
+      expect(errors?.['optionTextEmpty']).toBeUndefined(
+        'No debería haber error de opciones vacías si todas tienen texto'
+      );
+    });
+
+    it('debe crear exactamente 4 opciones al cambiar entre tipos de opción múltiple', () => {
+      const questionGroup = createQuestionGroup('MULTIPLE_CHOICE');
+      component.question = questionGroup as AbstractControl;
+      fixture.detectChanges();
+
+      questionGroup.get('type')?.setValue('MULTIPLE_SELECT');
+      component.onQuestionTypeChange();
+
+      const optionsAfter = (component.question as FormGroup).get('options') as FormArray;
+      expect(optionsAfter.length).toBe(4);
+    });
+
+    it('debe rellenar con texto vacío si el nuevo tipo tiene más opciones que las existentes', () => {
+      // Arrange: solo 2 opciones previas
+      const questionGroup = createQuestionGroup('TEXT');
+      const options = questionGroup.get('options') as FormArray;
+      while (options.length) options.removeAt(0);
+      options.push(createOptionGroup('Solo una opción'));
+      component.question = questionGroup as AbstractControl;
+      fixture.detectChanges();
+
+      // Act
+      questionGroup.get('type')?.setValue('MULTIPLE_CHOICE');
+      component.onQuestionTypeChange();
+
+      // Assert: 4 opciones, primera con texto, resto vacías
+      const optionsAfter = (component.question as FormGroup).get('options') as FormArray;
+      expect(optionsAfter.length).toBe(4);
+      expect(optionsAfter.at(0).get('text')?.value).toBe('Solo una opción');
+      expect(optionsAfter.at(1).get('text')?.value).toBe('');
+      expect(optionsAfter.at(2).get('text')?.value).toBe('');
+      expect(optionsAfter.at(3).get('text')?.value).toBe('');
+    });
+  });
+
+  // ── addOption / removeOption ────────────────────────────────────────────
+
+  describe('addOption()', () => {
+    it('debe agregar una opción vacía al array', () => {
+      const questionGroup = createQuestionGroup('MULTIPLE_CHOICE');
+      component.question = questionGroup as AbstractControl;
+      fixture.detectChanges();
+
+      const beforeCount = component.options.length;
+      component.addOption();
+      expect(component.options.length).toBe(beforeCount + 1);
+    });
+  });
+
+  describe('removeOption()', () => {
+    it('debe eliminar la opción en el índice indicado si hay más de 2', () => {
+      const questionGroup = createQuestionGroup('MULTIPLE_CHOICE');
+      component.question = questionGroup as AbstractControl;
+      fixture.detectChanges();
+
+      expect(component.options.length).toBe(4);
+      component.removeOption(0);
+      expect(component.options.length).toBe(3);
+    });
+
+    it('NO debe eliminar si solo hay 2 opciones', () => {
+      const questionGroup = createQuestionGroup('MULTIPLE_CHOICE');
+      const options = questionGroup.get('options') as FormArray;
+      while (options.length > 2) options.removeAt(options.length - 1);
+      component.question = questionGroup as AbstractControl;
+      fixture.detectChanges();
+
+      component.removeOption(0);
+      expect(component.options.length).toBe(2);
+    });
+  });
+
+  // ── toggleCorrectOption ─────────────────────────────────────────────────
+
+  describe('toggleCorrectOption()', () => {
+    it('debe agregar el índice a correctOptionIds si no estaba', () => {
+      const questionGroup = createQuestionGroup('MULTIPLE_SELECT');
+      component.question = questionGroup as AbstractControl;
+      fixture.detectChanges();
+
+      component.toggleCorrectOption(1);
+      expect(questionGroup.get('correctOptionIds')?.value).toContain('1');
+    });
+
+    it('debe quitar el índice de correctOptionIds si ya estaba', () => {
+      const questionGroup = createQuestionGroup('MULTIPLE_SELECT');
+      questionGroup.patchValue({ correctOptionIds: ['0', '1'] });
+      component.question = questionGroup as AbstractControl;
+      fixture.detectChanges();
+
+      component.toggleCorrectOption(1);
+      expect(questionGroup.get('correctOptionIds')?.value).not.toContain('1');
+    });
+  });
+
+  // ── onOptionTextChange ──────────────────────────────────────────────────
+
+  describe('onOptionTextChange()', () => {
+    it('debe actualizar el valor del control de texto en el índice correcto', () => {
+      const questionGroup = createQuestionGroup('MULTIPLE_CHOICE');
+      component.question = questionGroup as AbstractControl;
+      fixture.detectChanges();
+
+      component.onOptionTextChange('Nuevo texto', 2);
+      const options = (component.question as FormGroup).get('options') as FormArray;
+      expect(options.at(2).get('text')?.value).toBe('Nuevo texto');
+    });
+
+    it('debe marcar el control como touched', () => {
+      const questionGroup = createQuestionGroup('MULTIPLE_CHOICE');
+      component.question = questionGroup as AbstractControl;
+      fixture.detectChanges();
+
+      component.onOptionTextChange('Algo', 0);
+      const options = (component.question as FormGroup).get('options') as FormArray;
+      expect(options.at(0).get('text')?.touched).toBeTrue();
+    });
+  });
+});

--- a/src/app/features/profesor/questionnaires/question-item/question-item.component.ts
+++ b/src/app/features/profesor/questionnaires/question-item/question-item.component.ts
@@ -67,22 +67,37 @@ export class QuestionItemComponent implements OnDestroy {
   }
 
   onQuestionTypeChange() {
-    const type = (this.question as FormGroup).get('type')?.value;
-    const optionsArray = this.options;
+  const type = (this.question as FormGroup).get('type')?.value;
+  const optionsArray = this.options;
 
+  if (type === 'MULTIPLE_CHOICE' || type === 'MULTIPLE_SELECT') {
+    // Guardar los textos actuales antes de limpiar
+    const existingTexts: string[] = optionsArray.controls.map(
+      ctrl => ctrl.get('text')?.value || ''
+    );
+
+    // Limpiar opciones
     while (optionsArray.length) {
       optionsArray.removeAt(0);
     }
 
-    if (type === 'MULTIPLE_CHOICE' || type === 'MULTIPLE_SELECT') {
-      for (let i = 0; i < 4; i++) {
-        optionsArray.push(this.createOptionGroup());
-      }
+    // Recrear 4 opciones preservando el texto que ya había
+    for (let i = 0; i < 4; i++) {
+      const group = this.createOptionGroup();
+      const savedText = existingTexts[i] ?? '';
+      group.patchValue({ text: savedText });
+      optionsArray.push(group);
     }
-
-    (this.question as FormGroup).patchValue({ correctOptionId: '', correctOptionIds: [] });
-    (this.question as FormGroup).updateValueAndValidity();
+  } else {
+    // Si cambia a TEXT, limpiar opciones (no se necesitan)
+    while (optionsArray.length) {
+      optionsArray.removeAt(0);
+    }
   }
+
+  (this.question as FormGroup).patchValue({ correctOptionId: '', correctOptionIds: [] });
+  (this.question as FormGroup).updateValueAndValidity();
+}
 
   onMediaSelected(event: Event) {
     const input = event.target as HTMLInputElement;

--- a/src/app/features/profesor/questionnaires/questionnaire-edit/questionnaire-edit.component.html
+++ b/src/app/features/profesor/questionnaires/questionnaire-edit/questionnaire-edit.component.html
@@ -153,6 +153,7 @@
       </div>
 
       <!-- Configuration Card -->
+    @if (!questionnaireForm.get('isSurvey')?.value) {
       <div class="bg-white rounded-lg shadow-md p-6">
         <!-- Header Section -->
         <div class="border-b-2 border-b-brand-primary pb-2 mb-4">
@@ -243,6 +244,7 @@
           </div>
         </div>
       </div>
+    }
 
       <!-- Questions Card -->
       <div class="bg-white rounded-lg shadow-md p-6">

--- a/src/app/features/profesor/questionnaires/questionnaire-edit/questionnaire-edit.component.spec.ts
+++ b/src/app/features/profesor/questionnaires/questionnaire-edit/questionnaire-edit.component.spec.ts
@@ -1,8 +1,25 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { QuestionnaireEditComponent } from './questionnaire-edit.component';
-import { ReactiveFormsModule } from '@angular/forms';
+import { ReactiveFormsModule, FormGroup, FormArray, FormControl, Validators } from '@angular/forms';
 import { provideHttpClient } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
+
+import { QuestionnaireEditComponent } from './questionnaire-edit.component';
+
+// ─── Helper ─────────────────────────────────────────────────────────────────
+
+function buildOptionsArray(texts: string[]): FormArray {
+  const arr = new FormArray<FormGroup>([]);
+  texts.forEach(txt =>
+    arr.push(new FormGroup({
+      _id: new FormControl(null),
+      text: new FormControl(txt, [Validators.required]),
+      order: new FormControl(0)
+    }))
+  );
+  return arr;
+}
+
+// ─── Suite ──────────────────────────────────────────────────────────────────
 
 describe('QuestionnaireEditComponent', () => {
   let component: QuestionnaireEditComponent;
@@ -22,11 +39,11 @@ describe('QuestionnaireEditComponent', () => {
     fixture.detectChanges();
   });
 
+  // ── Tests existentes (Tarea #14: Encuestas) ──────────────────────────────
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
-
-  // --- TESTS DE LA TAREA #14: ENCUESTAS ---
 
   it('debe tener el control isSurvey en el formulario', () => {
     const isSurveyControl = component.questionnaireForm.get('isSurvey');
@@ -49,5 +66,148 @@ describe('QuestionnaireEditComponent', () => {
     };
     component.populateForm(mockSurvey as any);
     expect(component.questionnaireForm.get('isSurvey')?.value).toBeTrue();
+  });
+
+  // ── Tests nuevos: questionGroupValidator ─────────────────────────────────
+
+  describe('questionGroupValidator()', () => {
+
+    it('no debe retornar errores si todas las opciones tienen texto y hay respuesta correcta (MULTIPLE_CHOICE)', () => {
+      const group = new FormGroup({
+        type: new FormControl('MULTIPLE_CHOICE'),
+        options: buildOptionsArray(['Opción A', 'Opción B', 'Opción C', 'Opción D']),
+        correctOptionId: new FormControl('0'),
+        correctOptionIds: new FormControl<string[]>([])
+      });
+
+      const errors = (component as any).questionGroupValidator(group);
+      expect(errors).toBeNull();
+    });
+
+    it('no debe retornar errores si todas las opciones tienen texto y hay respuestas correctas (MULTIPLE_SELECT)', () => {
+      const group = new FormGroup({
+        type: new FormControl('MULTIPLE_SELECT'),
+        options: buildOptionsArray(['Opción A', 'Opción B', 'Opción C']),
+        correctOptionId: new FormControl(''),
+        correctOptionIds: new FormControl<string[]>(['0', '2'])
+      });
+
+      const errors = (component as any).questionGroupValidator(group);
+      expect(errors).toBeNull();
+    });
+
+    it('no debe retornar errores para preguntas de tipo TEXT', () => {
+      const group = new FormGroup({
+        type: new FormControl('TEXT'),
+        options: new FormArray([]),
+        correctOptionId: new FormControl(''),
+        correctOptionIds: new FormControl<string[]>([])
+      });
+
+      const errors = (component as any).questionGroupValidator(group);
+      expect(errors).toBeNull();
+    });
+
+    it('NO debe reportar optionTextEmpty si las opciones preservadas tienen texto tras cambiar tipo — bug #reporte', () => {
+      // Reproduce exactamente el bug: usuario tenía MULTIPLE_CHOICE con 4 opciones
+      // completas y cambió a MULTIPLE_SELECT. El validador no debe ver opciones vacías.
+      const group = new FormGroup({
+        type: new FormControl('MULTIPLE_SELECT'),
+        options: buildOptionsArray(['Alpha', 'Beta', 'Gamma', 'Delta']),
+        correctOptionId: new FormControl(''),
+        correctOptionIds: new FormControl<string[]>(['0'])
+      });
+
+      const errors = (component as any).questionGroupValidator(group);
+      expect(errors?.['optionTextEmpty']).toBeUndefined(
+        'No debe haber error de opciones vacías cuando todas tienen texto'
+      );
+    });
+
+    it('debe reportar optionTextEmpty si hay opciones sin texto', () => {
+      const group = new FormGroup({
+        type: new FormControl('MULTIPLE_CHOICE'),
+        options: buildOptionsArray(['Opción A', '', 'Opción C', '']),
+        correctOptionId: new FormControl('0'),
+        correctOptionIds: new FormControl<string[]>([])
+      });
+
+      const errors = (component as any).questionGroupValidator(group);
+      expect(errors?.['optionTextEmpty']).toContain('2 opción(es) sin texto');
+    });
+
+    it('debe reportar optionsCount si hay menos de 2 opciones', () => {
+      const group = new FormGroup({
+        type: new FormControl('MULTIPLE_CHOICE'),
+        options: buildOptionsArray(['Única opción']),
+        correctOptionId: new FormControl('0'),
+        correctOptionIds: new FormControl<string[]>([])
+      });
+
+      const errors = (component as any).questionGroupValidator(group);
+      expect(errors?.['optionsCount']).toBeTruthy();
+    });
+
+    it('debe reportar noCorrect si no se selecciona opción correcta en MULTIPLE_CHOICE', () => {
+      const group = new FormGroup({
+        type: new FormControl('MULTIPLE_CHOICE'),
+        options: buildOptionsArray(['A', 'B', 'C', 'D']),
+        correctOptionId: new FormControl(''),
+        correctOptionIds: new FormControl<string[]>([])
+      });
+
+      const errors = (component as any).questionGroupValidator(group);
+      expect(errors?.['noCorrect']).toBeTruthy();
+    });
+
+    it('debe reportar noCorrect si no se selecciona ninguna opción en MULTIPLE_SELECT', () => {
+      const group = new FormGroup({
+        type: new FormControl('MULTIPLE_SELECT'),
+        options: buildOptionsArray(['A', 'B', 'C']),
+        correctOptionId: new FormControl(''),
+        correctOptionIds: new FormControl<string[]>([])
+      });
+
+      const errors = (component as any).questionGroupValidator(group);
+      expect(errors?.['noCorrect']).toBeTruthy();
+    });
+
+    it('NO debe modificar los errores de controles hijos válidos', () => {
+      // El validador anterior llamaba setErrors({ required: true }) en controles hijos.
+      // El fix elimina ese comportamiento.
+      const optA = new FormControl('Texto ok', [Validators.required]);
+      const optB = new FormControl('', [Validators.required]);
+
+      const group = new FormGroup({
+        type: new FormControl('MULTIPLE_CHOICE'),
+        options: new FormArray([
+          new FormGroup({ _id: new FormControl(null), text: optA, order: new FormControl(0) }),
+          new FormGroup({ _id: new FormControl(null), text: optB, order: new FormControl(0) })
+        ]),
+        correctOptionId: new FormControl('0'),
+        correctOptionIds: new FormControl<string[]>([])
+      });
+
+      const errorsAntes = optA.errors;
+      (component as any).questionGroupValidator(group);
+
+      expect(optA.errors).toEqual(errorsAntes,
+        'El validador padre no debe sobreescribir los errores de controles hijos válidos'
+      );
+    });
+
+    it('puede reportar múltiples errores a la vez', () => {
+      const group = new FormGroup({
+        type: new FormControl('MULTIPLE_CHOICE'),
+        options: buildOptionsArray(['']),
+        correctOptionId: new FormControl(''),
+        correctOptionIds: new FormControl<string[]>([])
+      });
+
+      const errors = (component as any).questionGroupValidator(group);
+      expect(errors?.['optionsCount']).toBeTruthy();
+      expect(errors?.['optionTextEmpty']).toBeTruthy();
+      expect(errors?.['noCorrect']).toBeTruthy();
+    });
   });
 });

--- a/src/app/features/profesor/questionnaires/questionnaire-edit/questionnaire-edit.component.ts
+++ b/src/app/features/profesor/questionnaires/questionnaire-edit/questionnaire-edit.component.ts
@@ -437,52 +437,48 @@ export class QuestionnaireEditComponent implements OnInit {
   }
 
   // Validator for each question group
-  private questionGroupValidator(control: AbstractControl): ValidationErrors | null {
-    const type = control.get('type')?.value;
-    const options = control.get('options') as FormArray | null;
-    const errors: any = {};
+private questionGroupValidator(control: AbstractControl): ValidationErrors | null {
+  const type = control.get('type')?.value;
+  const options = control.get('options') as FormArray | null;
+  const errors: any = {};
 
-    if (type === 'MULTIPLE_CHOICE' || type === 'MULTIPLE_SELECT') {
-      if (!options || options.length < 2) {
-        errors.optionsCount = 'Debe haber al menos 2 opciones';
-      }
+  if (type === 'MULTIPLE_CHOICE' || type === 'MULTIPLE_SELECT') {
+    if (!options || options.length < 2) {
+      errors.optionsCount = 'Debe haber al menos 2 opciones';
+    }
 
-      // Ensure every option has text
-      if (options) {
-        const emptyIndexes: number[] = [];
-        for (let i = 0; i < options.length; i++) {
-          const txtCtrl = options.at(i).get('text');
-          const txtVal = txtCtrl?.value;
-          if (!txtVal || (typeof txtVal === 'string' && txtVal.trim() === '')) {
-            emptyIndexes.push(i);
-            // mark control as touched so template shows per-option error
-            try { txtCtrl?.markAsTouched(); } catch {}
-            // explicitly set required error so control.invalid becomes true
-            try { txtCtrl?.setErrors({ required: true }); } catch {}
-          }
-        }
-        if (emptyIndexes.length) {
-          errors.optionTextEmpty = `Hay ${emptyIndexes.length} opción(es) sin texto`;
+    if (options) {
+      const emptyIndexes: number[] = [];
+      for (let i = 0; i < options.length; i++) {
+        const txtCtrl = options.at(i).get('text');
+        const txtVal = txtCtrl?.value;
+        // ✅ Solo evaluar el valor real, sin tocar ni setear errores en el control hijo
+        if (!txtVal || (typeof txtVal === 'string' && txtVal.trim() === '')) {
+          emptyIndexes.push(i);
         }
       }
-
-      if (type === 'MULTIPLE_CHOICE') {
-        const correct = control.get('correctOptionId')?.value;
-        if (correct === null || correct === undefined || correct === '') {
-          errors.noCorrect = 'Selecciona una opción correcta';
-        }
-      }
-
-      if (type === 'MULTIPLE_SELECT') {
-        const corrects = control.get('correctOptionIds')?.value || [];
-        if (!Array.isArray(corrects) || corrects.length === 0) {
-          errors.noCorrect = 'Selecciona al menos una opción correcta';
-        }
+      if (emptyIndexes.length) {
+        errors.optionTextEmpty = `Hay ${emptyIndexes.length} opción(es) sin texto`;
       }
     }
 
-    return Object.keys(errors).length ? errors : null;
+    if (type === 'MULTIPLE_CHOICE') {
+      const correct = control.get('correctOptionId')?.value;
+      if (correct === null || correct === undefined || correct === '') {
+        errors.noCorrect = 'Selecciona una opción correcta';
+      }
+    }
+
+    if (type === 'MULTIPLE_SELECT') {
+      const corrects = control.get('correctOptionIds')?.value || [];
+      if (!Array.isArray(corrects) || corrects.length === 0) {
+        errors.noCorrect = 'Selecciona al menos una opción correcta';
+      }
+    }
   }
+
+  return Object.keys(errors).length ? errors : null;
+}
 
   private updateAfterClassValidators(posType: string | null) {
     const afterClassControl = this.questionnaireForm.get('afterClassId');

--- a/src/app/features/profesor/questionnaires/teacher-questionnaires.component.html
+++ b/src/app/features/profesor/questionnaires/teacher-questionnaires.component.html
@@ -135,6 +135,11 @@
             @if (questionnaire.description) {
               <p class="text-white text-sm line-clamp-2">{{ questionnaire.description }}</p>
             }
+            @if (questionnaire.isSurvey) {
+              <span class="inline-block mt-2 px-2 py-0.5 text-xs font-semibold bg-white/20 text-white rounded-full">
+                📋 Encuesta de Satisfacción
+              </span>
+            }
           </div>
 
           <!-- Body -->
@@ -158,45 +163,60 @@
             </div>
 
             <!-- Settings -->
-            <div class="space-y-2 text-sm text-brand-tertiary mb-4">
-              @if (questionnaire.passingScore) {
+            @if (!questionnaire.isSurvey) {
+              <div class="space-y-2 text-sm text-brand-tertiary mb-4">
+                @if (questionnaire.passingScore) {
+                  <div class="flex items-center gap-2">
+                    <svg class="w-4 h-4 text-brand-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                    <span>Nota mínima: {{ questionnaire.passingScore }}%</span>
+                  </div>
+                }
+                <div class="flex items-center gap-2">
+                  <svg class="w-4 h-4 text-brand-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                  </svg>
+                  @if (questionnaire.allowRetries) {
+                    @if (questionnaire.maxRetries) {
+                      <span>Hasta {{ questionnaire.maxRetries }} intentos</span>
+                    } @else {
+                      <span>Intentos ilimitados</span>
+                    }
+                  } @else {
+                    <span>Sin reintentos</span>
+                  }
+                </div>
+                <div class="flex items-center gap-2">
+                  <svg class="w-4 h-4 text-brand-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                  </svg>
+                  @if (questionnaire.showCorrectAnswers) {
+                    <span>Muestra respuestas correctas</span>
+                  } @else {
+                    <span>Oculta respuestas correctas</span>
+                  }
+                </div>
+              </div>
+            } @else {
+              <div class="space-y-2 text-sm text-brand-tertiary mb-4">
+                <div class="flex items-center gap-2">
+                  <svg class="w-4 h-4 text-brand-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  <span class="text-brand-primary font-medium">Puntuación automática: 100%</span>
+                </div>
                 <div class="flex items-center gap-2">
                   <svg class="w-4 h-4 text-brand-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
-                  <span>Nota mínima: {{ questionnaire.passingScore }}%</span>
+                  <span>No evalúa respuestas correctas</span>
                 </div>
-              }
-
-              <div class="flex items-center gap-2">
-                <svg class="w-4 h-4 text-brand-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                </svg>
-                @if (questionnaire.allowRetries) {
-                  @if (questionnaire.maxRetries) {
-                    <span>Hasta {{ questionnaire.maxRetries }} intentos</span>
-                  } @else {
-                    <span>Intentos ilimitados</span>
-                  }
-                } @else {
-                  <span>Sin reintentos</span>
-                }
               </div>
+            }
 
-              <div class="flex items-center gap-2">
-                <svg class="w-4 h-4 text-brand-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                </svg>
-                @if (questionnaire.showCorrectAnswers) {
-                  <span>Muestra respuestas correctas</span>
-                } @else {
-                  <span>Oculta respuestas correctas</span>
-                }
-              </div>
-            </div>
-
-            <!-- Actions -->
+                        <!-- Actions -->
             <div class="flex gap-2 pt-4 border-t border-gray-200">
               <button
                 (click)="viewResults(questionnaire); $event.stopPropagation()"


### PR DESCRIPTION

- Card del listado: oculta nota mínima, reintentos y respuestas correctas cuando isSurvey=true
- Card del listado: muestra badge '📋 Encuesta de Satisfacción' y info alternativa
- Formulario de edición: oculta sección Configuración cuando isSurvey=true
- Agrega tests e2e para verificar el comportamiento
Relacionada con la Issue encuestas de satisfaccion #13 
<img width="1565" height="774" alt="encuestas de satis" src="https://github.com/user-attachments/assets/84d95d9b-6626-4217-a911-eb28f83420d2" />