### PR TITLE
Cancel-button

### DIFF
--- a/src/app/features/profesor/students/teacher-students.component.ts
+++ b/src/app/features/profesor/students/teacher-students.component.ts
@@ -1,5 +1,4 @@
 import { Component, inject, signal, computed, OnInit, OnDestroy } from '@angular/core';
-
 import { FormsModule } from '@angular/forms';
 import { Router, NavigationEnd, ActivatedRoute } from '@angular/router';
 import { filter, Subscription } from 'rxjs';
@@ -86,6 +85,7 @@ export class TeacherStudentsComponent implements OnInit, OnDestroy {
     confirmText: 'Generar',
     cancelText: 'Cancelar',
     confirmButtonClass: 'bg-green-600 hover:bg-green-700',
+    cancelButtonClass: 'bg-white hover:bg-gray-100 border border-gray-400',
     icon: 'info'
   };
   generatingCertificate = signal<boolean>(false);
@@ -99,6 +99,7 @@ export class TeacherStudentsComponent implements OnInit, OnDestroy {
     confirmText: 'Resetear',
     cancelText: 'Cancelar',
     confirmButtonClass: 'bg-red-600 hover:bg-red-700',
+    cancelButtonClass: 'bg-white hover:bg-gray-100 border border-gray-400',
     icon: 'danger'
   };
   resettingProgress = signal<boolean>(false);
@@ -112,6 +113,7 @@ export class TeacherStudentsComponent implements OnInit, OnDestroy {
     confirmText: 'Desasociar',
     cancelText: 'Cancelar',
     confirmButtonClass: 'bg-red-600 hover:bg-red-700',
+    cancelButtonClass: 'bg-white hover:bg-gray-100 border border-gray-400',
     icon: 'danger'
   };
   unenrollingStudent = signal<boolean>(false);

--- a/src/app/shared/components/confirm-modal/confirm-modal.component.html
+++ b/src/app/shared/components/confirm-modal/confirm-modal.component.html
@@ -37,6 +37,7 @@
           {{ config.confirmText || 'Confirmar' }}
         </button>
         <button type="button" (click)="onCancel()"
+          [ngClass]="config.cancelButtonClass || ''"
           class="cursor-pointer text-sm bg-transparent font-bold inline-flex items-center border transition-all py-2 rounded-full px-4"
           style="color: var(--color-brand-tertiary); border-color: var(--color-brand-tertiary-lighten);">
           {{ config.cancelText || 'Cancelar' }}

--- a/src/app/shared/components/confirm-modal/confirm-modal.component.ts
+++ b/src/app/shared/components/confirm-modal/confirm-modal.component.ts
@@ -7,6 +7,7 @@ export interface ConfirmModalConfig {
   confirmText?: string;
   cancelText?: string;
   confirmButtonClass?: string;
+  cancelButtonClass?: string;
   icon?: 'warning' | 'danger' | 'info' | 'success';
 }
 


### PR DESCRIPTION
### Tarea:
Cambiar el estilo del botón cancelar para evitar que se camufle con el fondo.

### Cambios:
- Se agregó ngClass y cancelButtonClass al modal para permitir cambiar el estilo del botón.
- Se cambió el color del botón gris a un color blanco para que resalte.