### PR TITLE
fix/#106

### DIFF
--- a/src/app/features/profesor/questionnaires/questionnaire-edit/questionnaire-edit.component.html
+++ b/src/app/features/profesor/questionnaires/questionnaire-edit/questionnaire-edit.component.html
@@ -126,10 +126,12 @@
               Posición
             </label>
             <select
-              id="positionType"
-              formControlName="positionType"
-              class="cursor-pointer w-full px-3 py-2 border border-gray-300 rounded-md transition focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary placeholder-gray-400"
+            id="positionType"
+            formControlName="positionType"
+            [attr.disabled]="questionnaireForm.get('isSurvey')?.value ? true : null"
+            class="cursor-pointer w-full px-3 py-2 border border-gray-300 rounded-md transition focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary placeholder-gray-400 disabled:bg-gray-100 disabled:text-gray-400 disabled:cursor-not-allowed"
             >
+      
               @if (questionnaireForm.get('status')?.value === 'DRAFT') {
                 <option value="">Sin definir (Borrador)</option>
               }

--- a/src/app/features/profesor/questionnaires/questionnaire-edit/questionnaire-edit.component.ts
+++ b/src/app/features/profesor/questionnaires/questionnaire-edit/questionnaire-edit.component.ts
@@ -191,6 +191,20 @@ export class QuestionnaireEditComponent implements OnInit {
     this.questionnaireForm.get('positionType')?.valueChanges.subscribe((posType) => {
       this.updateAfterClassValidators(posType);
     });
+    // Subscribe to isSurvey changes to disable/enable positionType
+    this.questionnaireForm.get('isSurvey')?.valueChanges.subscribe((isSurvey) => {
+      const positionTypeControl = this.questionnaireForm.get('positionType');
+      if (isSurvey) {
+        positionTypeControl?.setValue('FINAL_EXAM', { emitEvent: false });
+        positionTypeControl?.disable({ emitEvent: false });
+        this.updateAfterClassValidators('FINAL_EXAM');
+      } else {
+        positionTypeControl?.enable({ emitEvent: false });
+      }
+    });
+
+// Run initial configuration
+this.updateStatusBasedValidators(this.questionnaireForm.get('status')?.value);
 
     // Run initial configuration
     this.updateStatusBasedValidators(this.questionnaireForm.get('status')?.value);


### PR DESCRIPTION
fix/#106 — Encuestas de satisfacción no permiten seleccionar posición entre clases
Al marcar "Encuesta de Satisfacción", el selector de posición se deshabilita automáticamente y se setea a "Examen Final", ya que las encuestas siempre se ubican al final del curso.
<img width="1399" height="790" alt="encuesta" src="https://github.com/user-attachments/assets/14545664-85c9-4668-ac54-6596a299443d" />
