### PR TITLE
fix/#31

### DIFF
--- a/src/app/features/profesor/courses/course-edit/course-edit.component.html
+++ b/src/app/features/profesor/courses/course-edit/course-edit.component.html
@@ -202,39 +202,50 @@
       </div>
 
       <!-- Fechas -->
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-8">
+<div class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-8">
 
-        
-        <!-- Fecha de Inicio -->
-        <div>
-          <label for="startDate" class="block text-base font-bold text-brand-tertiary mb-2">
-            Fecha de Inicio <span class="text-red-500">*</span>
-          </label>
-          <input
-            type="date"
-            id="startDate"
-            formControlName="startDate"
-            class="cursor-pointer w-full px-3 py-2 border border-gray-300 rounded-md transition focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary placeholder-gray-400"
-          />
-          @if (courseForm.get('startDate')?.invalid && courseForm.get('startDate')?.touched) {
-            <p class="mt-1 text-sm text-red-600">La fecha de inicio es requerida</p>
-          }
-        </div>
+  <!-- Fecha de Inicio -->
+  <div>
+    <label for="startDate" class="block text-base font-bold text-brand-tertiary mb-2">
+      Fecha de Inicio <span class="text-red-500">*</span>
+    </label>
+    <input
+      type="date"
+      id="startDate"
+      formControlName="startDate"
+      [min]="courseForm.get('registrationOpenDate')?.value || ''"
+      class="cursor-pointer w-full px-3 py-2 border border-gray-300 rounded-md transition focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary placeholder-gray-400"
+    />
+    @if (courseForm.get('startDate')?.invalid && courseForm.get('startDate')?.touched) {
+      <p class="mt-1 text-sm text-red-600">La fecha de inicio es requerida</p>
+    }
+  </div>
 
-        <!-- Fecha de inscripción -->
-        <div class="">
-          <label for="registrationOpenDate" class="block text-base font-bold text-brand-tertiary mb-2">
-            Fecha de Apertura de Inscripciones
-          </label>
-          <input
-            type="date"
-            id="registrationOpenDate"
-            formControlName="registrationOpenDate"
-            class="cursor-pointer w-full px-3 py-2 border border-gray-300 rounded-md transition focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary placeholder-gray-400"
-          />
-        </div>
-      </div>
+  <!-- Fecha de inscripción -->
+  <div>
+    <label for="registrationOpenDate" class="block text-base font-bold text-brand-tertiary mb-2">
+      Fecha de Apertura de Inscripciones
+    </label>
+    <input
+      type="date"
+      id="registrationOpenDate"
+      formControlName="registrationOpenDate"
+      [max]="courseForm.get('startDate')?.value || ''"
+      class="cursor-pointer w-full px-3 py-2 border border-gray-300 rounded-md transition focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary placeholder-gray-400"
+    />
+  </div>
 
+</div>
+
+<!-- ✅ Error de validación cruzada de fechas -->
+@if (courseForm.errors?.['startBeforeRegistration'] && 
+     courseForm.get('startDate')?.touched && 
+     courseForm.get('registrationOpenDate')?.touched) {
+  <p class="mb-4 text-sm text-red-600">
+    La fecha de inicio debe ser posterior a la fecha de apertura de inscripciones.
+  </p>
+}
+      
       <!-- Días, Hora,  -->
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
         <div>

--- a/src/app/features/profesor/courses/course-edit/course-edit.component.ts
+++ b/src/app/features/profesor/courses/course-edit/course-edit.component.ts
@@ -43,23 +43,37 @@ export class CourseEditComponent implements OnInit {
   }
 
   initForm(): void {
-    this.courseForm = this.fb.group({
-      name: ['', [Validators.required]],
-      description: ['', [Validators.maxLength(350)]],
-      longDescription: ['', [Validators.maxLength(850)]],
-      modality: ['', [Validators.required]],
-      price: [0],
-      maxInstallments: [1],
-      interestFree: [false],
-      days: ['', [Validators.required]],
-      time: ['', [Validators.required, Validators.pattern(/^([01]\d|2[0-3]):([0-5]\d)$/)]],
-      startDate: ['', [Validators.required]],
-      registrationOpenDate: [''],
-      numberOfClasses: [0, [Validators.required, Validators.min(1)]],
-      duration: [0, [Validators.required, Validators.min(0.5)]],
-      imageFile: [null]
-    });
-  }
+  this.courseForm = this.fb.group({
+    name: ['', [Validators.required]],
+    description: ['', [Validators.maxLength(350)]],
+    longDescription: ['', [Validators.maxLength(850)]],
+    modality: ['', [Validators.required]],
+    price: [0],
+    maxInstallments: [1],
+    interestFree: [false],
+    days: ['', [Validators.required]],
+    time: ['', [Validators.required, Validators.pattern(/^([01]\d|2[0-3]):([0-5]\d)$/)]],
+    startDate: ['', [Validators.required]],
+    registrationOpenDate: [''],
+    numberOfClasses: [0, [Validators.required, Validators.min(1)]],
+    duration: [0, [Validators.required, Validators.min(0.5)]],
+    imageFile: [null]
+  });
+
+  // ✅ Validador cruzado: fecha de inicio debe ser posterior a fecha de inscripción
+  this.courseForm.addValidators((group) => {
+    const startDate = group.get('startDate')?.value;
+    const registrationOpenDate = group.get('registrationOpenDate')?.value;
+    if (startDate && registrationOpenDate) {
+      const start = new Date(startDate);
+      const registration = new Date(registrationOpenDate);
+      if (start < registration) {
+        return { startBeforeRegistration: true };
+      }
+    }
+    return null;
+  });
+} // ← esta llave cierra initForm()
 
   loadCourse(): void {
     if (!this.courseId) return;


### PR DESCRIPTION
Problema: El formulario de edición de curso no validaba el orden cronológico entre la fecha de apertura de inscripciones y la fecha de inicio del curso, permitiendo guardar configuraciones inválidas.
Solución:

- Se agregó un validador cruzado en initForm() que retorna el error startBeforeRegistration cuando startDate < registrationOpenDate
- Se agregó [min] en el input de startDate con el valor de registrationOpenDate, bloqueando fechas anteriores desde el calendario nativo
- Se agregó [max] en el input de registrationOpenDate con el valor de startDate, bloqueando fechas posteriores desde el calendario nativo
- Se inhabilita la posibilidad de seleccionar una fecha igual o mayor a la de inicio
<img width="1614" height="949" alt="{B5637894-D041-4AA9-8F81-EB6316A6E9B6}" src="https://github.com/user-attachments/assets/7e9fa918-c15d-46be-a2b4-b813e39c408e" />
