### PR TITLE
Botón Cancelar

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,27 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+    - name: Install dependencies
+      run: npm ci
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+    - name: Run Playwright tests
+      run: npx playwright test
+    - uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/e2e/example.spec.ts
+++ b/e2e/example.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test('has title', async ({ page }) => {
+  await page.goto('https://playwright.dev/');
+
+  // Expect a title "to contain" a substring.
+  await expect(page).toHaveTitle(/Playwright/);
+});
+
+test('get started link', async ({ page }) => {
+  await page.goto('https://playwright.dev/');
+
+  // Click the get started link.
+  await page.getByRole('link', { name: 'Get started' }).click();
+
+  // Expects page to have a heading with the name of Installation.
+  await expect(page.getByRole('heading', { name: 'Installation' })).toBeVisible();
+});

--- a/src/app/features/profesor/classes/class-edit/class-edit.component.ts
+++ b/src/app/features/profesor/classes/class-edit/class-edit.component.ts
@@ -76,6 +76,7 @@ export class TeacherClassEditComponent implements OnInit, OnDestroy, AfterViewIn
     confirmText: 'Eliminar',
     cancelText: 'Cancelar',
     confirmButtonClass: 'bg-red-600 hover:bg-red-700',
+    cancelButtonClass: 'bg-white hover:bg-gray-100 border border-gray-400',
     icon: 'danger'
   };
 

--- a/src/app/features/profesor/questionnaires/questionnaire-results/questionnaire-results.component.ts
+++ b/src/app/features/profesor/questionnaires/questionnaire-results/questionnaire-results.component.ts
@@ -52,7 +52,8 @@ export class QuestionnaireResultsComponent implements OnInit {
     confirmText: 'Resetear',
     cancelText: 'Cancelar',
     icon: 'danger',
-    confirmButtonClass: 'bg-red-600 hover:bg-red-700'
+    confirmButtonClass: 'bg-red-600 hover:bg-red-700',
+    cancelButtonClass: 'bg-white hover:bg-gray-100 border border-gray-400',
   };
 
   // View state

--- a/src/app/features/profesor/questionnaires/teacher-questionnaires.component.ts
+++ b/src/app/features/profesor/questionnaires/teacher-questionnaires.component.ts
@@ -49,7 +49,8 @@ export class TeacherQuestionnairesComponent implements OnInit {
     message: '¿Estás seguro de que deseas eliminar este cuestionario?',
     confirmText: 'Eliminar',
     cancelText: 'Cancelar',
-    confirmClass: 'bg-red-600 hover:bg-red-700'
+    confirmClass: 'bg-red-600 hover:bg-red-700',
+    cancelButtonClass: 'bg-white hover:bg-gray-100 border border-gray-400',
   };
 
   ngOnInit(): void {


### PR DESCRIPTION
### Tarea:
Arreglar estilo del botón cancelar.

### Cambios:
- Se agregó un estilo a los botones Cancelar, asignándoles un color blanco.
- Dicho estilo se agregó a los botones de los siguientes modales:
1. El modal de eliminar clase en la pantalla de Editar clase.
2. El modal de eliminar cuestionario en la pantalla Mis cuestionarios.
3. El modal de resetear cuestionario en la pantalla Ver resultados de los cuestionarios.