### PR TITLE
feat(profesor): vista documentacion #45 - galeria, filtro por categor…

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -50,6 +50,7 @@ export const routes: Routes = [
         path: '',
         loadComponent: () => import('./features/admin/dashboard/admin-dashboard.component').then(m => m.AdminDashboardComponent)
       },
+
       {
         path: 'users',
         loadComponent: () => import('./features/admin/users/users.component').then(m => m.UsersComponent)
@@ -124,6 +125,10 @@ export const routes: Routes = [
       {
         path: '',
         loadComponent: () => import('./features/profesor/dashboard/profesor-dashboard.component').then(m => m.ProfesorDashboardComponent)
+      },
+            {
+      path: 'documentation',
+      loadComponent: () => import('./features/profesor/documentation/profesor-documentation.component').then(m => m.ProfesorDocumentationComponent)
       },
       {
         path: 'courses',

--- a/src/app/core/models/documentation.model.ts
+++ b/src/app/core/models/documentation.model.ts
@@ -1,0 +1,12 @@
+export type DocumentCategory = 'PLANTILLAS' | 'LOGOS' | 'IMAGENES' | 'OTROS';
+
+export interface IDocument {
+  _id: string;
+  title: string;
+  filename: string;
+  category: DocumentCategory;
+  url: string;
+  sizeBytes: number;
+  visibility?: 'PROFESORES' | 'TODOS';
+  updatedAt?: string;
+}

--- a/src/app/core/services/documentation.service.ts
+++ b/src/app/core/services/documentation.service.ts
@@ -1,0 +1,37 @@
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { AuthService } from './auth.service';
+import { UserRole } from '../models/user-role.enum';
+import { IDocument } from '../models/documentation.model';
+
+// este service es temporal falta la tarea 43 pimero
+@Injectable({ providedIn: 'root' })
+export class DocumentationService {
+  private authService = inject(AuthService);
+
+  private readonly _documents = signal<IDocument[]>(MOCK_DOCUMENTS);
+  readonly documents = this._documents.asReadonly();
+
+  // filtrado por rol
+  readonly filteredDocuments = computed<IDocument[]>(() => {
+    const docs = this._documents();
+    if (this.authService.hasRole(UserRole.ADMIN)) return docs;
+    return docs.filter(d => !d.visibility || d.visibility === 'TODOS' || d.visibility === 'PROFESORES');
+  });
+
+  readonly signedContract = signal<IDocument | null>(MOCK_CONTRACT);
+}
+
+const MB = 1024 * 1024;
+
+const MOCK_CONTRACT: IDocument = {
+  _id: 'c1', title: 'Tu contrato firmado', filename: 'contrato-firmado.pdf',
+  category: 'OTROS', url: 'https://dev-cursala.b-cdn.net/support-materials/contrato-firmado.pdf',
+  sizeBytes: 1.4 * MB, visibility: 'PROFESORES', updatedAt: '2024-05-14',
+};
+
+const MOCK_DOCUMENTS: IDocument[] = [
+  { _id: '1', title: 'Reglamento Docente', filename: 'reglamento-docente.pdf', category: 'OTROS', url: 'https://dev-cursala.b-cdn.net/support-materials/reglamento-docente.pdf', sizeBytes: 1.2 * MB, visibility: 'PROFESORES' },
+  { _id: '2', title: 'Guía del Profesor', filename: 'guia-del-profesor.pptx', category: 'PLANTILLAS', url: 'https://dev-cursala.b-cdn.net/support-materials/guia-del-profesor.pptx', sizeBytes: 3.4 * MB, visibility: 'PROFESORES' },
+  { _id: '3', title: 'Logo Cursala', filename: 'logo-cursala.png', category: 'LOGOS', url: 'https://dev-cursala.b-cdn.net/support-materials/logo-cursala.png', sizeBytes: 3.2 * MB, visibility: 'PROFESORES' },
+  { _id: '4', title: 'Políticas Institucionales', filename: 'politicas-institucionales.pdf', category: 'OTROS', url: 'https://dev-cursala.b-cdn.net/support-materials/politicas-institucionales.pdf', sizeBytes: 0.87 * MB, visibility: 'PROFESORES' },
+];

--- a/src/app/features/profesor/documentation/profesor-documentation.component.html
+++ b/src/app/features/profesor/documentation/profesor-documentation.component.html
@@ -1,0 +1,105 @@
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    @if (esProfesor()) {
+
+  <!-- Encabezado -->
+  <div class="mb-6">
+    <h1 class="text-2xl font-semibold text-brand-tertiary">Documentación</h1>
+    <p class="text-sm text-brand-tertiary-light mt-1">
+      entra a todos los documentos disponibles para tu rol y descarga los que necesites
+    </p>
+  </div>
+
+  <!-- Seccion destacada: contrato firmado. @if = se muestra solo si existe. -->
+  @if (signedContract(); as contract) {
+    <div class="bg-brand-tertiary-lighten/20 border border-brand-tertiary-lighten/40 rounded-xl p-5 mb-8 flex flex-col sm:flex-row sm:items-center gap-4">
+      <div class="h-14 w-14 rounded-lg bg-brand-primary/10 flex items-center justify-center shrink-0">
+        <svg class="h-7 w-7 text-brand-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+      </div>
+      <div class="flex-1">
+        <p class="text-base font-semibold text-brand-tertiary">{{ contract.title }}</p>
+        <p class="text-sm text-brand-tertiary-light">Descarga tu contrato firmado y sellado.</p>
+        @if (contract.updatedAt) {
+          <span class="inline-block mt-2 text-xs bg-white text-brand-tertiary-light px-2 py-1 rounded-md border border-gray-200">
+            Actualizado el {{ contract.updatedAt }}
+          </span>
+        }
+      </div>
+      <button (click)="downloadFile(contract.url, contract.filename)"
+        class="inline-flex items-center justify-center gap-2 bg-brand-primary text-white text-sm font-medium px-4 py-2.5 rounded-lg hover:opacity-90 transition-opacity cursor-pointer">
+        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a2 2 0 002 2h12a2 2 0 002-2v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+        </svg>
+        Descargar PDF
+      </button>
+    </div>
+  }
+
+  <!-- Buscador (visual por ahora; la lógica va en la #46) -->
+  <div class="relative mb-5 max-w-md">
+    <svg class="h-4 w-4 text-gray-400 absolute left-3 top-1/2 -translate-y-1/2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M17 11a6 6 0 11-12 0 6 6 0 0112 0z" />
+    </svg>
+    <input type="text" placeholder="Buscar documentos..." disabled
+      class="w-full pl-9 pr-3 py-2.5 text-sm border border-gray-200 rounded-lg bg-gray-50 text-gray-400 cursor-not-allowed" />
+  </div>
+
+  <!-- Botones de categoría. @for recorre el array 'categories'. -->
+  <div class="flex flex-wrap gap-2 mb-6">
+    @for (cat of categories; track cat) {
+      <button (click)="selectCategory(cat)"
+        [class.bg-brand-primary]="selectedCategory() === cat"
+        [class.text-white]="selectedCategory() === cat"
+        [class.bg-white]="selectedCategory() !== cat"
+        [class.text-brand-tertiary]="selectedCategory() !== cat"
+        class="text-sm px-4 py-1.5 rounded-full border border-gray-200 hover:border-brand-primary transition-colors cursor-pointer">
+        {{ cat }}
+      </button>
+    }
+  </div>
+
+  <h2 class="text-sm font-semibold text-brand-tertiary mb-4">Todos los documentos</h2>
+
+  <!-- Grilla de tarjetas. Si hay docs las dibuja; si no, muestra el estado vacío. -->
+  @if (visibleDocuments().length > 0) {
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      @for (doc of visibleDocuments(); track doc._id) {
+        <div class="bg-white border border-gray-200 rounded-xl p-4 shadow-xs hover:shadow-md transition-shadow">
+          <div class="flex items-start gap-3">
+            <!-- Badge del tipo de archivo (color según iconClasses) -->
+            <div class="h-11 w-11 rounded-lg flex items-center justify-center text-[11px] font-bold shrink-0" [class]="iconClasses(doc.filename)">
+              {{ fileExtension(doc.filename) }}
+            </div>
+            <div class="min-w-0 flex-1">
+              <p class="text-sm font-medium text-brand-tertiary truncate">{{ doc.title }}</p>
+              <p class="text-xs text-brand-tertiary-light mt-0.5">
+                {{ fileExtension(doc.filename) }} · {{ formatSize(doc.sizeBytes) }}
+              </p>
+            </div>
+          </div>
+          <button (click)="downloadFile(doc.url, doc.filename)"
+            class="mt-4 w-full inline-flex items-center justify-center gap-2 text-sm font-medium text-brand-primary border border-brand-primary/30 rounded-lg py-2 hover:bg-brand-primary/5 transition-colors cursor-pointer">
+            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a2 2 0 002 2h12a2 2 0 002-2v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+            </svg>
+            Descargar
+          </button>
+        </div>
+      }
+    </div>
+  } @else {
+    <div class="text-center py-16 text-brand-tertiary-light">
+      <p class="text-sm">No hay documentos en esta categoría.</p>
+    </div>
+  }
+
+  <p class="text-center text-xs text-brand-tertiary-light mt-10">
+    ¿No encuentras lo que buscas? Contacta a administración.
+  </p>
+} @else {
+    <div class="text-center py-16 text-brand-tertiary-light">
+      <p class="text-sm">esta seccion es solo para profesores</p>
+    </div>
+  }
+</div>

--- a/src/app/features/profesor/documentation/profesor-documentation.component.ts
+++ b/src/app/features/profesor/documentation/profesor-documentation.component.ts
@@ -1,0 +1,89 @@
+import { Component, computed, inject, signal } from '@angular/core';
+import { DocumentationService } from '../../../core/services/documentation.service';
+import { IDocument, DocumentCategory } from '../../../core/models/documentation.model';
+import { AuthService } from '../../../core/services/auth.service';
+import { UserRole } from '../../../core/models/user-role.enum';
+
+//filtro de categorias esta sumando 'TODOS' ademas de las otras 4 categorias reales 
+type CategoryFilter = 'TODOS' | DocumentCategory;
+
+@Component({
+  selector: 'app-profesor-documentation', // asi se llama la etiqueta del componente
+  standalone: true,                        // componente independiente (sin NgModule)
+  imports: [],
+  templateUrl: './profesor-documentation.component.html', 
+})
+export class ProfesorDocumentationComponent {
+  // aca inyectamos el service para pedirle los documentos
+  private documentationService = inject(DocumentationService);
+  private authService = inject(AuthService);
+  // valida que el rol activo sea estrictamente profesor
+  readonly esProfesor = computed(() => this.authService.hasRole(UserRole.PROFESOR));
+
+  // documentos ya filtrados por rol + el contrato firmado (vienen del service)
+  readonly documents = this.documentationService.filteredDocuments;
+  readonly signedContract = this.documentationService.signedContract;
+
+  // botones de categoria que se muestran arriba de la grilla
+  readonly categories: CategoryFilter[] = ['TODOS', 'PLANTILLAS', 'LOGOS', 'IMAGENES', 'OTROS'];
+
+  // categoria activa. Es una signal: al cambiarla, la vista se recalcula solas
+  readonly selectedCategory = signal<CategoryFilter>('TODOS');
+
+
+  //  lista final y computed = se recalcula solo, filtra en memoria 
+  readonly visibleDocuments = computed<IDocument[]>(() => {
+    const cat = this.selectedCategory();
+    const docs = this.documents();
+    return cat === 'TODOS' ? docs : docs.filter(d => d.category === cat);
+  });
+
+  // cambia la categoria activa
+  selectCategory(cat: CategoryFilter): void {
+    this.selectedCategory.set(cat);
+  }
+
+  // pasa bytes
+  formatSize(bytes: number): string {
+    return bytes >= 1024 * 1024
+      ? `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+      : `${Math.round(bytes / 1024)} KB`;
+  }
+
+  fileExtension(filename: string): string {
+    const parts = filename.split('.');
+    return parts.length > 1 ? parts.pop()!.toUpperCase() : 'FILE';
+  }
+
+  // color del badge 
+  iconClasses(filename: string): string {
+    const ext = this.fileExtension(filename).toLowerCase();
+    switch (ext) {
+      case 'pdf': return 'bg-red-100 text-red-600';
+      case 'doc': case 'docx': return 'bg-blue-100 text-blue-600';
+      case 'xls': case 'xlsx': return 'bg-green-100 text-green-600';
+      case 'ppt': case 'pptx': return 'bg-orange-100 text-orange-600';
+      case 'png': case 'jpg': case 'jpeg': case 'gif': return 'bg-purple-100 text-purple-600';
+      case 'zip': case 'rar': return 'bg-yellow-100 text-yellow-700';
+      default: return 'bg-gray-100 text-gray-600';
+    }
+  }
+
+
+  async downloadFile(url: string, filename: string): Promise<void> {
+    try {
+      const response = await fetch(url);
+      const blob = await response.blob();
+      const blobUrl = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = blobUrl;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(blobUrl);
+    } catch {
+      window.open(url, '_blank');
+    }
+  }
+}

--- a/src/app/shared/layouts/teacher-layout/teacher-layout.component.ts
+++ b/src/app/shared/layouts/teacher-layout/teacher-layout.component.ts
@@ -141,7 +141,10 @@ export class TeacherLayoutComponent implements OnInit, OnDestroy {
     {
       label: 'Mis Alumnos',
       route: '/profesor/students'
-    }
+    },
+    { 
+      label: 'Documentación', route: '/profesor/documentation'
+    },
   ];
 
 


### PR DESCRIPTION
## 📝 Descripción del Cambio
Se implementa la vista de galería y descarga de documentación para el perfil **Profesor** (`features/profesor/documentation`), dando cumplimiento a la subtarea **#45**.

## 🛠️ Cambios Incluidos
- **Ruteo & Layout:** Incorporación de la ruta lazy-loaded `/profesor/documentation` en `app.routes.ts` y agregado del ítem de navegación en `teacher-layout.component.ts`.
- **Estado Reactivo (Signals):** Manejo de filtros locales mediante la signal `selectedCategory` y derivación de datos con `computed()`, evitando peticiones HTTP redundantes.
- **Modelado & Servicios:** Extensión de `IDocument` en `documentation.model.ts` y centralización del estado de documentos en `DocumentationService`.
- **Descargas CDN:** Implementación del helper `downloadFile()` mediante peticiones `blob` para el consumo seguro desde Bunny Storage (`*.b-cdn.net`).
- **Seguridad UI:** Verificación estricta de rol `PROFESOR` mediante `AuthService` para garantizar una vista de solo lectura.

## 🧪 Pruebas Sustantivas
- [x] Ruteo y carga del componente Standalone en navegador.
- [x] Filtrado reactivo en cliente por categorías (`PLANTILLAS`, `LOGOS`, `IMAGENES`, `OTROS`).
- [x] Verificación de descarga directa de archivos PDF/imágenes desde CDN.
- [x] Control de renderizado condicional según el rol activo del usuario.

Closes #45